### PR TITLE
Mocked the client thereby fixing many issues

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./src/client-mock.ts"

--- a/src/client-mock.ts
+++ b/src/client-mock.ts
@@ -1,0 +1,44 @@
+import { mock } from "bun:test"
+
+/*
+
+NOTE(pauek):
+We fully mock the client module, so we can test the JOM without
+having to do any of the API calls, and ensuring we can test way faster.
+
+*/
+
+mock.module("./client", () => ({
+    AuthService: {},
+    OpenAPI: {},
+    StudentCoursesService: {
+        getAvailableCourses: async () => ({ courses: [] }),
+        getEnrolledCourses: async () => ({ courses: [] }),
+    },
+    StudentListsService: {
+        getLists: async () => ({ lists: [] }),
+        getList: async () => ({ list: {} }),
+    },
+    MiscService: {
+        hello: () => ({ message: "Hello World!" }),
+        getFortune: async () => ({ message: "You will be successful" }),
+        getTime: async () => ({ time: "2021-10-10T10:10:10Z", date: "2021-10-10" }),
+        getHomepageStats: async () => ({ users: 100, problems: 1000, submissions: 234234 }),
+        ping: async () => "",
+    },
+    StudentProblemsService: {
+        getAbstractProblems: async () => ({ "X12345": [] }),
+    },
+    StudentProfileService: {
+        getProfile: async () => ({ nickname: "pauek" }),
+        getAvatar: async () => new Blob(),
+    },
+    TablesService: {
+        getLanguages: async () => ({ ca: { hello: true } }),
+        getCountries: async () => ({ cat: { yay: 13 } }),
+        getCompilers: async () => ({ py: { ext: ".py" } }),
+        getDrivers: async () => ({ std: { driver_id: "std" } }),
+        getVerdicts: async () => ({ AC: { verdict_id: "AC" } }),
+        getProglangs: async () => ({ C: { proglang_id: "C" } }),
+    },
+}))

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -21,10 +21,7 @@ describe("Misc", () => {
         expect(time).toHaveProperty("date")
     })
 
-    // FIXME(pauek): Seems like @hey-api/openapi-ts returns "undefined" when it should return an empty string?
-    // Do we have to change the API? I hope not...
-    // (it is skipped for now)
-    test.skip("misc.ping()", async () => {
+    test("misc.ping()", async () => {
         const pong = await jom.misc.ping()
         expect(pong).toBe("")
     })

--- a/src/problems.test.ts
+++ b/src/problems.test.ts
@@ -5,17 +5,15 @@ import { describeWithToken } from "./test-utils"
 describeWithToken("Problems", () => {
     const jom = new JOM()
 
-    // FIXME(pauek): The API is giving internal error for now
-    test.skip("problems.all()", async () => {
+    test("problems.all()", async () => {
         const problems = await jom.problems.all()
-        console.log("Number of problems:", Object.keys(problems).length)
         expect(Object.keys(problems).length).toBeGreaterThan(0)
     })
 
-    // FIXME(pauek): The API is giving internal error for now
-    test.skip("problems.get()", async () => {
+    test("problems.get()", async () => {
         const problems = await jom.problems.all()
         const problemId = Object.keys(problems)[0]
         const problem = await jom.problems.get(problemId)
+        expect(problem).toBeDefined()
     })
 })

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -22,9 +22,9 @@ export class Problems {
             if (!abstractProblem) {
                 return undefined
             }
-            for (const problem of abstractProblem.problems) {
-                if (problem.problem_id === problem_key) {
-                    return problem
+            for (const problem_id in abstractProblem.problems) {
+                if (problem_id === problem_key) {
+                    return abstractProblem.problems[problem_id]
                 }
             }
             return undefined

--- a/src/tables.test.ts
+++ b/src/tables.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { JutgeObjectModel as JOM } from "./jom"
 
-describe("Tables", () => {
+describe("Tables", async () => {
     const jom = new JOM()
 
     test.each([
-        ["countries", jom.countries, "ES-Cat", "eng_name", "Spain - Catalunya"],
-        ["compilers", jom.compilers, "Python3", "extension", "py"],
-        ["languages", jom.languages, "ca", "own_name", "Català"],
+        ["languages", jom.languages, "ca", "hello", true],
+        ["countries", jom.countries, "cat", "yay", 13],
+        ["compilers", jom.compilers, "py", "ext", ".py"],
         ["drivers", jom.drivers, "std", "driver_id", "std"],
         ["verdicts", jom.verdicts, "AC", "verdict_id", "AC"],
         ["proglangs", jom.proglangs, "C", "proglang_id", "C"],

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -1,6 +1,5 @@
-import {
+import type {
     CancelablePromise,
-    TablesService,
     TCompiler,
     TCountry,
     TDriver,
@@ -9,15 +8,34 @@ import {
     TVerdict,
 } from "./client"
 
-type TableFetchFunc = () => CancelablePromise<Record<string, unknown>>
+import { TablesService } from "./client"
 
-const TableClass = <T>(fetchFunc: TableFetchFunc) =>
+type TableFetchFunc = () => CancelablePromise<Record<string, unknown>>
+type TableType =
+    | "languages"
+    | "countries"
+    | "compilers"
+    | "drivers"
+    | "verdicts"
+    | "proglangs"
+
+const fetchFunc: Record<TableType, TableFetchFunc> = {
+    languages: TablesService.getLanguages,
+    countries: TablesService.getCountries,
+    compilers: TablesService.getCompilers,
+    drivers: TablesService.getDrivers,
+    verdicts: TablesService.getVerdicts,
+    proglangs: TablesService.getProglangs,
+}
+
+const TableClass = <T>(funcName: TableType) =>
     class {
         items: Map<string, T> | undefined
 
         async reload() {
+            const func = fetchFunc[funcName]
             this.items = new Map(
-                Object.entries((await fetchFunc()) as Record<string, T>)
+                Object.entries((await func()) as Record<string, T>)
             )
         }
 
@@ -42,17 +60,9 @@ const TableClass = <T>(fetchFunc: TableFetchFunc) =>
         }
     }
 
-export class Languages extends TableClass<TLanguage>(
-    TablesService.getLanguages
-) {}
-export class Countries extends TableClass<TCountry>(
-    TablesService.getCountries
-) {}
-export class Compilers extends TableClass<TCompiler>(
-    TablesService.getCompilers
-) {}
-export class Drivers extends TableClass<TDriver>(TablesService.getDrivers) {}
-export class Verdicts extends TableClass<TVerdict>(TablesService.getVerdicts) {}
-export class ProgLangs extends TableClass<TProglang>(
-    TablesService.getProglangs
-) {}
+export class Languages extends TableClass<TLanguage>("languages") {}
+export class Countries extends TableClass<TCountry>("countries") {}
+export class Compilers extends TableClass<TCompiler>("compilers") {}
+export class Drivers extends TableClass<TDriver>("drivers") {}
+export class Verdicts extends TableClass<TVerdict>("verdicts") {}
+export class ProgLangs extends TableClass<TProglang>("proglangs") {}


### PR DESCRIPTION
I went ahead and mocked the API Client (the generated one). This seems a little too much at first, but the advantage is great: you don't depend on the real API to work, nor have to wait 80-100ms for each call, so the whole test suite takes just 90ms to run. 

The `bunfig.toml` file contains the "preload" module that does the mocking (it is important that it is loaded before any other module tries to load it). Fortunately Bun has this mechanism ready. 

The best usage of all of this is opening a console with `bun test --watch` and change the code, and see if the changes you made break anything. Now there is not so much code, but when we get to caghing, it will be way more complex, so having this in place is a good idea.

